### PR TITLE
Error endpoint /professional corregido en AccountControllers

### DIFF
--- a/Safad/Controllers/AccountController.cs
+++ b/Safad/Controllers/AccountController.cs
@@ -56,11 +56,11 @@ namespace Safad.Controllers
                 {
                     if (!user.Registration)
                     {
-                        return RedirectToAction("CreateUserProfesional", "Profesional");
+                        return RedirectToAction("CreateUserProfesional", "Professional");
                     }
                     else
                     {
-                        return RedirectToAction("IndexProfesional", "Profesional");
+                        return RedirectToAction("IndexProfesional", "Professional");
                     }
                 }
                 if (role.RoleId == 4)


### PR DESCRIPTION
Se corrigio el error de que en vez de que vaya a /Profesional que no es el endpoint vaya a /Professional que si es el endpoint solicitado